### PR TITLE
Upgrade to akka 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: scala
+jdk:
+  - oraclejdk8
 scala:
    - 2.11.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: scala
 scala:
-   - 2.10.5
-   - 2.11.7
+   - 2.11.8

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Current versions:
 
-- `akka-http-*`: `1.0`
+- `akka-http-*`: `2.4.4`
 - `metrics-core`: `3.1.2`
 
 ## Install & Usage

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,7 @@ organization := "backline"
 
 version := "0.2.0"
 
-scalaVersion := "2.11.7"
-
-crossScalaVersions ++= Seq("2.10.5", "2.11.7")
+scalaVersion := "2.11.8"
 
 resolvers ++= Seq(
   "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
@@ -16,9 +14,9 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
-  "com.typesafe.akka" %% "akka-http-experimental" % "1.0",
-  "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0",
-  "com.typesafe.akka" %% "akka-stream-experimental" % "1.0"
+  "com.typesafe.akka" %% "akka-http-experimental" % "2.4.4",
+  "com.typesafe.akka" %% "akka-http-core" % "2.4.4",
+  "com.typesafe.akka" %% "akka-stream" % "2.4.4"
 )
 
 resolvers ++= Seq(
@@ -28,8 +26,8 @@ resolvers ++= Seq(
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.6.2" % "test",
-  "com.typesafe.akka" %% "akka-http-testkit-experimental" % "1.0" % "test"
+  "org.specs2" %% "specs2-core" % "3.7" % "test",
+  "com.typesafe.akka" %% "akka-http-testkit" % "2.4.4" % "test"
 )
 
 bintrayOrganization in bintray := Some("backline")

--- a/src/test/scala/RouteSpecification.scala
+++ b/src/test/scala/RouteSpecification.scala
@@ -1,7 +1,6 @@
 package backline.http.metrics
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, MediaTypes, MessageEntity}
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server.{RoutingLog, RoutingSettings, RoutingSetup}
 import akka.http.scaladsl.testkit.{TestFrameworkInterface, RouteTest, RouteTestTimeout}
 import org.specs2.execute.{Failure, FailureException}
 import org.specs2.mutable.Specification
@@ -23,9 +22,4 @@ trait Specs2Interface extends TestFrameworkInterface {
 
 class RouteSpecification extends Specification with RouteTest with Specs2Interface { spec =>
   implicit def routeTestTimeout: RouteTestTimeout = RouteTestTimeout(FiniteDuration(5, "seconds"))
-
-  protected implicit lazy val routingSettings = RoutingSettings.apply(system)
-  protected implicit lazy val routingLog = RoutingLog.fromActorSystem(system)
-
-  implicit def routingSetup: RoutingSetup = RoutingSetup.apply
 }


### PR DESCRIPTION
This drops support for scala 2.10 as it seems akka has dropped support
for akka-http-* under 2.10.x also.