### PR TITLE
timerDirective now takes an optional custom reservoir

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import bintray.Keys._
 
 name := "akka-http-metrics"
 
-version := "0.3.1"
+version := "0.3.2"
 
 scalaVersion := "2.11.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,7 @@ import bintray.Keys._
 
 name := "akka-http-metrics"
 
-organization := "backline"
-
-version := "0.3.0"
+version := "0.3.1"
 
 scalaVersion := "2.11.8"
 
@@ -32,11 +30,10 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion % "test"
 )
 
-bintrayOrganization in bintray := Some("backline")
 
 bintrayPublishSettings ++ Seq(
   publishArtifact in Test := false,
   repository in bintray := "open-source",
-  homepage := Some(url("https://github.com/backline/akka-http-metrics")),
+  homepage := Some(url("https://github.com/queirozfcom/akka-http-metrics")),
   licenses ++= Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")))
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,5 @@ resolvers += Resolver.url(
   url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
   Resolver.ivyStylePatterns)
 
+
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")

--- a/src/main/scala/HttpTimerMetrics.scala
+++ b/src/main/scala/HttpTimerMetrics.scala
@@ -1,12 +1,13 @@
 package backline.http.metrics
+
 import com.codahale.metrics._
 import akka.http.scaladsl.server.Directive0
 import scala.util.control.NonFatal
 
 trait HttpTimerMetrics extends MetricsBase {
-  def timerDirective: Directive0 = {
+  def timerDirective(customReservoir: Option[Reservoir] = None): Directive0 = {
     mapInnerRoute { inner => ctx =>
-      val timer = findAndRegisterTimer(getMetricName(ctx)).time()
+      val timer = findAndRegisterTimer(getMetricName(ctx), customReservoir).time()
       try {
         inner(ctx)
       } catch {

--- a/src/main/scala/MetricsBase.scala
+++ b/src/main/scala/MetricsBase.scala
@@ -1,4 +1,5 @@
 package backline.http.metrics
+
 import com.codahale.metrics._
 import java.util.Iterator
 import akka.actor.Status.Failure
@@ -9,9 +10,13 @@ import scala.util.control.NonFatal
 trait MetricsBase extends BasicDirectives {
   def metricRegistry: MetricRegistry
 
-  protected def findAndRegisterTimer(name: String): Timer = {
+  protected def findAndRegisterTimer(name: String, customReservoir: Option[Reservoir]): Timer = {
     val found = metricRegistry.getTimers(new NameBasedMetricFilter(name)).values.iterator
-    findAndRegisterMetric(name, new Timer(), found)
+
+    customReservoir match {
+      case Some(reservoir) => findAndRegisterMetric(name, new Timer(reservoir), found)
+      case None => findAndRegisterMetric(name, new Timer(), found)
+    }
   }
 
   protected def findAndRegisterCounter(name: String): Counter = {
@@ -46,4 +51,5 @@ trait MetricsBase extends BasicDirectives {
   protected class NameBasedMetricFilter(needle: String) extends MetricFilter {
     def matches(name: String, metric: Metric): Boolean = name equalsIgnoreCase needle
   }
+
 }


### PR DESCRIPTION
I did this because I wanted to use a custom reservoir such as [this](https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir) when collecting my metrics
