### PR TITLE
Downgrading akka deps to allow cross compile to scala 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Current versions:
 
-- `akka-http-*`: `2.4.4`
+- `akka-http-*`: `2.0.4`
 - `metrics-core`: `3.1.2`
 
 ## Install & Usage

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ version := "0.3.0"
 
 scalaVersion := "2.11.8"
 
-val akkaVersion = "2.4.8"
+crossScalaVersions := Seq("2.10.6", "2.11.8")
+
+val akkaVersion = "2.0.4"
 
 resolvers ++= Seq(
   "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
@@ -17,8 +19,8 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
   "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion,
-  "com.typesafe.akka" %% "akka-http-core" % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % akkaVersion
+  "com.typesafe.akka" %% "akka-http-core-experimental" % akkaVersion,
+  "com.typesafe.akka" %% "akka-stream-experimental" % akkaVersion
 )
 
 resolvers ++= Seq(
@@ -29,7 +31,7 @@ scalacOptions in Test ++= Seq("-Yrangepos")
 
 libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "3.7" % "test",
-  "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion % "test"
+  "com.typesafe.akka" %% "akka-http-testkit-experimental" % akkaVersion % "test"
 )
 
 bintrayOrganization in bintray := Some("backline")


### PR DESCRIPTION
We would like to use this library for metrics, but we are currently forced to stay on scala 2.10. 

This PR will let us use this library as a proper dependency, although it will downgrade the akka dependencies listed to `*-experimental` releases.