### PR TITLE
Adding support for custom metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1 (Unreleased)
+
+- Adding support for custom names in meter, timer, and response code metrics.
+
 # 0.4.0 (Released 2016-12-02)
 
 - Bump akka-http version to `10.0.0`

--- a/src/main/scala/HttpMeterMetrics.scala
+++ b/src/main/scala/HttpMeterMetrics.scala
@@ -1,12 +1,18 @@
 package backline.http.metrics
 import com.codahale.metrics._
-import akka.http.scaladsl.server.Directive0
+import akka.http.scaladsl.server.{Directive0, RequestContext}
 import scala.util.control.NonFatal
 
 trait HttpMeterMetrics extends MetricsBase {
-  def meterDirective: Directive0 = {
+  def meterDirective: Directive0 =
+    meter(ctx => getMetricName(ctx))
+
+  def meterDirectiveWithName(name: String): Directive0 =
+    meter(_ => name)
+
+  private[this] def meter(nameFunc: RequestContext => String): Directive0 = {
     mapInnerRoute { inner => ctx =>
-      findAndRegisterMeter(getMetricName(ctx)).mark
+      findAndRegisterMeter(nameFunc(ctx)).mark
       try {
         inner(ctx)
       } catch {

--- a/src/main/scala/HttpTimerMetrics.scala
+++ b/src/main/scala/HttpTimerMetrics.scala
@@ -1,12 +1,18 @@
 package backline.http.metrics
 import com.codahale.metrics._
-import akka.http.scaladsl.server.Directive0
+import akka.http.scaladsl.server.{Directive0, RequestContext}
 import scala.util.control.NonFatal
 
 trait HttpTimerMetrics extends MetricsBase {
-  def timerDirective: Directive0 = {
+  def timerDirective: Directive0 =
+    timer(ctx => getMetricName(ctx))
+
+  def timerDirectiveWithName(name: String): Directive0 =
+    timer(_ => name)
+
+  private[this] def timer(nameFunc: RequestContext => String): Directive0 = {
     mapInnerRoute { inner => ctx =>
-      val timer = findAndRegisterTimer(getMetricName(ctx)).time()
+      val timer = findAndRegisterTimer(nameFunc(ctx)).time()
       try {
         inner(ctx)
       } catch {

--- a/src/main/scala/ResponseCodeMetrics.scala
+++ b/src/main/scala/ResponseCodeMetrics.scala
@@ -1,25 +1,31 @@
 package backline.http.metrics
 import com.codahale.metrics._
-import akka.http.scaladsl.server.{Directive0, RouteResult}
+import akka.http.scaladsl.server.{Directive0, RequestContext, RouteResult}
 import akka.http.scaladsl.model.{StatusCodes, StatusCode}
 import scala.util.control.NonFatal
 import scala.concurrent.ExecutionContext
 
 trait ResponseCodeMetrics extends MetricsBase {
-  def responseCodeMetrics(implicit ec: ExecutionContext): Directive0 = {
+  def responseCodeMetrics(implicit ec: ExecutionContext): Directive0 =
+    responseCodes(ctx => getMetricName(ctx))
+
+  def responseCodeMetricsWithName(name: String)(implicit ec: ExecutionContext): Directive0 =
+    responseCodes(_ => name)
+
+  private[this] def responseCodes(nameFunc: RequestContext => String)(implicit ec: ExecutionContext): Directive0 = {
     mapInnerRoute { inner => ctx =>
       try {
         val fut = inner(ctx)
         fut foreach {
           case RouteResult.Complete(resp) =>
-            findAndRegisterCounter(s"${getMetricName(ctx)}-${liftStatusCode(resp.status)}").inc
+            findAndRegisterCounter(s"${nameFunc(ctx)}-${liftStatusCode(resp.status)}").inc
           case RouteResult.Rejected(_) =>
-            findAndRegisterCounter(s"${getMetricName(ctx)}-rejections").inc
+            findAndRegisterCounter(s"${nameFunc(ctx)}-rejections").inc
         }
         fut
       } catch {
         case NonFatal(err) =>
-          findAndRegisterCounter(s"${getMetricName(ctx)}-failures").inc
+          findAndRegisterCounter(s"${nameFunc(ctx)}-failures").inc
           ctx.fail(err)
       }
     }

--- a/src/test/scala/HttpMeterMetricsSpec.scala
+++ b/src/test/scala/HttpMeterMetricsSpec.scala
@@ -8,12 +8,20 @@ object HttpMeterMetricsSpec extends RouteSpecification with HttpMeterMetrics wit
   val metricRegistry = new MetricRegistry()
 
   "record rates for /ping" in {
+    def routes =
+      meterDirective {
+        (get & path("ping")) {
+          complete("pong")
+        }
+      }
+
     (1 to 60) foreach { _ =>
       Get("/ping") ~> routes ~> check {
         status === StatusCodes.OK
         responseAs[String].contains("pong") must beTrue
       }
     }
+
     val meter = metricRegistry.meter("ping.GET")
     meter.getCount must be_==(60)
     meter.getMeanRate must beGreaterThan(60D)
@@ -21,10 +29,25 @@ object HttpMeterMetricsSpec extends RouteSpecification with HttpMeterMetrics wit
     meter.getOneMinuteRate must beGreaterThan(1D).eventually(5, 1000 millis)
   }
 
-  def routes =
-    meterDirective {
-      (get & path("ping")) {
-        complete("pong")
+  "work with custom names" in {
+    def routes =
+      meterDirectiveWithName("ping-route") {
+        (get & path("ping")) {
+          complete("pong")
+        }
+      }
+
+    (1 to 100) foreach { _ =>
+      Get("/ping") ~> routes ~> check {
+        status === StatusCodes.OK
+        responseAs[String].contains("pong") must beTrue
       }
     }
+
+    val meter = metricRegistry.meter("ping-route")
+    meter.getCount must be_==(100)
+    meter.getMeanRate must beGreaterThan(100D)
+    meter.getMeanRate must beLessThan(101D).eventually(5, 1000 millis)
+    meter.getOneMinuteRate must beGreaterThan(1D).eventually(5, 1000 millis)
+  }
 }

--- a/src/test/scala/HttpTimerMetricsSpec.scala
+++ b/src/test/scala/HttpTimerMetricsSpec.scala
@@ -20,6 +20,17 @@ object HttpTimerMetricsSpec extends RouteSpecification with HttpTimerMetrics wit
     counts.getCount() must be_==(1000).eventually
   }
 
+  "work with custom names" in {
+    (1 to 1000) foreach { _ =>
+      Get("/ping3") ~> routes ~> check {
+        status === StatusCodes.OK
+        responseAs[String].contains("pong3") must beTrue
+      }
+    }
+    val counts = metricRegistry.timer("other-ping")
+    counts.getCount() must be_==(1000).eventually
+  }
+
   "the slow route should take over a second" in {
     (1 to 5) foreach { _ =>
       Get("/slow") ~> routes ~> check {
@@ -67,6 +78,11 @@ object HttpTimerMetricsSpec extends RouteSpecification with HttpTimerMetrics wit
       (get & path("slow")) {
         Thread.sleep(1000)
         complete("awake")
+      }
+    } ~
+    timerDirectiveWithName("other-ping") {
+      (get & path("ping3")) {
+        complete("pong3")
       }
     }
 }

--- a/src/test/scala/ResponseCodeMetrics.scala
+++ b/src/test/scala/ResponseCodeMetrics.scala
@@ -17,6 +17,16 @@ object ResponseCodeMetricsSpec extends RouteSpecification with ResponseCodeMetri
     counts.getCount() must be_==(1000)
   }
 
+  "count up for successful requests with custom name" in {
+    (1 to 1000) foreach { _ =>
+      Get("/ok") ~> routes2 ~> check {
+        status === StatusCodes.OK
+      }
+    }
+    val counts = metricRegistry.counter("other-name-2xx")
+    counts.getCount() must be_==(1000)
+  }
+
   "count up for redirecting requests" in {
     (1 to 1000) foreach { _ =>
       Get("/redirect") ~> routes ~> check {
@@ -24,6 +34,16 @@ object ResponseCodeMetricsSpec extends RouteSpecification with ResponseCodeMetri
       }
     }
     val counts = metricRegistry.counter("redirect.GET-3xx")
+    counts.getCount() must be_==(1000)
+  }
+
+  "count up for redirecting requests with custom name" in {
+    (1 to 1000) foreach { _ =>
+      Get("/redirect") ~> routes2 ~> check {
+        status === StatusCodes.Found
+      }
+    }
+    val counts = metricRegistry.counter("other-name-3xx")
     counts.getCount() must be_==(1000)
   }
 
@@ -37,6 +57,16 @@ object ResponseCodeMetricsSpec extends RouteSpecification with ResponseCodeMetri
     counts.getCount() must be_==(1000)
   }
 
+  "count up for bad requests with custom name" in {
+    (1 to 1000) foreach { _ =>
+      Get("/bad") ~> routes2 ~> check {
+        status === StatusCodes.BadRequest
+      }
+    }
+    val counts = metricRegistry.counter("other-name-4xx")
+    counts.getCount() must be_==(1000)
+  }
+
   "count up for failing requests" in {
     (1 to 1000) foreach { _ =>
       Get("/fail") ~> routes ~> check {
@@ -47,8 +77,34 @@ object ResponseCodeMetricsSpec extends RouteSpecification with ResponseCodeMetri
     counts.getCount() must be_==(1000)
   }
 
+  "count up for failing requests with custom name" in {
+    (1 to 1000) foreach { _ =>
+      Get("/fail") ~> routes2 ~> check {
+        status === StatusCodes.InternalServerError
+      }
+    }
+    val counts = metricRegistry.counter("other-name-5xx")
+    counts.getCount() must be_==(1000)
+  }
+
   def routes =
     responseCodeMetrics(ExecutionContext.global) {
+      (get & path("ok")) {
+        complete(StatusCodes.OK)
+      } ~
+      (get & path("redirect")) {
+        redirect("/other", StatusCodes.Found)
+      } ~
+      (get & path("bad")) {
+        complete(StatusCodes.BadRequest)
+      } ~
+      (get & path("fail")) {
+        complete(StatusCodes.InternalServerError)
+      }
+    }
+
+  def routes2 =
+    responseCodeMetricsWithName("other-name")(ExecutionContext.global) {
       (get & path("ok")) {
         complete(StatusCodes.OK)
       } ~


### PR DESCRIPTION
From https://github.com/Backline/akka-http-metrics/issues/11 this adds new `*WithName` functions to timer and meter directives. 

I don't think we're going to be able to get custom names to work under the existing names. There's conflicts with which override is taken. 