### PR TITLE
Properly handle route completions that have futures

### DIFF
--- a/src/main/scala/HttpTimerMetrics.scala
+++ b/src/main/scala/HttpTimerMetrics.scala
@@ -11,15 +11,11 @@ trait HttpTimerMetrics extends MetricsBase {
     timer(_ => name)
 
   private[this] def timer(nameFunc: RequestContext => String): Directive0 = {
-    mapInnerRoute { inner => ctx =>
+    extractRequestContext.flatMap { ctx ⇒
       val timer = findAndRegisterTimer(nameFunc(ctx)).time()
-      try {
-        inner(ctx)
-      } catch {
-        case NonFatal(err) =>
-          ctx.fail(err)
-      } finally {
+      mapRouteResult { result ⇒
         timer.stop()
+        result
       }
     }
   }


### PR DESCRIPTION
This starts the timer around the initial request and stops the timer
after the response has been created. There's some extra cycles included
here, but this approach works for timing futures.

Fixes: https://github.com/Backline/akka-http-metrics/issues/13