### PR TITLE
Cross build for 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ jdk:
   - oraclejdk8
 scala:
    - 2.11.8
+   - 2.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.3 (Unreleased)
+
+- Cross compile to support Scala 2.11 and 2.12
+
 # 0.4.2 (Released 2016-12-08)
 
 - Fix timing for routes that have Futures

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-core" % akkaVersion,
   "com.typesafe.akka" %% "akka-http" % akkaVersion,
   // Tests
-  "org.specs2" %% "specs2-core" % "3.7" % "test",
+  "org.specs2" %% "specs2-core" % "3.8.6" % "test",
   "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ version := "0.4.3-dev"
 
 scalaVersion := "2.11.8"
 
+crossScalaVersions := Seq(scalaVersion.value, "2.12.1")
+
 val akkaVersion = "10.0.0"
 
 resolvers ++= Seq(


### PR DESCRIPTION
[2.12.1](http://www.scala-lang.org/news/2.12.1) has been released. 

I'm getting a cross dep error with scala-xml for 2.11 on the 2.12 build. Let's see if CI gets the same error. 