### PR TITLE
Update Scala versions and sbt plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 jdk:
-  - oraclejdk9
+  - oraclejdk8
 scala:
-   - 2.11.11
-   - 2.12.4
+   - 2.11.12
+   - 2.12.6
+script: sbt ++$TRAVIS_SCALA_VERSION! test

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import bintray.Keys._
 
 name := "akka-http-metrics"
 
@@ -6,15 +5,7 @@ organization := "backline"
 
 version := "1.0.0"
 
-scalaVersion := "2.11.8"
-
-crossScalaVersions := Seq(scalaVersion.value, "2.12.1")
-
 val akkaVersion = "10.0.6"
-
-resolvers ++= Seq(
-  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
-)
 
 libraryDependencies ++= Seq(
   "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
@@ -25,17 +16,10 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion % "test"
 )
 
-resolvers ++= Seq(
-  "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
-)
-
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 bintrayOrganization in bintray := Some("backline")
 
-bintrayPublishSettings ++ Seq(
-  publishArtifact in Test := false,
-  repository in bintray := "open-source",
-  homepage := Some(url("https://github.com/backline/akka-http-metrics")),
-  licenses ++= Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")))
-)
+bintrayRepository := "open-source"
+
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.url(
   url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
   Resolver.ivyStylePatterns)
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")


### PR DESCRIPTION
This will also pass the tests:
- Move to JDK8 instead of 9. Java 11 will be the next LTS release, so it makes sense to stick with the current LTS 8.
- I've bumped some Scala versions to the latest minor version.
- Updated to the latest `sbt-bintray` release.

Let me know what you think. Cheers